### PR TITLE
Fix lamrongol feature add minimized condition

### DIFF
--- a/WinBGMute/MainForm.cs
+++ b/WinBGMute/MainForm.cs
@@ -246,7 +246,7 @@ namespace WinBGMuter
                     }
                     else
                     {
-                        bool force_mute = false;
+                        bool force_mute = true;
                         // if not on mute list and 
                         if (!m_isMuteConditionBackground)
                         {
@@ -257,25 +257,19 @@ namespace WinBGMuter
                             if (!IsIconic(handle))
                             {
                                 // if minimize option AND NOT minimized: SKIP
+                                force_mute = false;
                                 log_skipped += "[M]" + audio_pname + ", ";
-
                             }
                             else
                             {
                                 // if minimize option and minimzed, do mute
                                 force_mute = true;
                             }
-
                         }
 
                         //mute the process and similar-named processes. Note that this may break multi-window muting 
                         // TODO: fix multi-window muting
-                        if (force_mute)
-                        {
-                            m_volumeMixer.SetApplicationMute(audio_pid, true);
-                            InlineMuteProcList(audio_proc_list, true);
-                        }
-
+                        InlineMuteProcList(audio_proc_list, force_mute);
 
                         log_muted += audio_pname + ", ";
                     }

--- a/WinBGMute/MainForm.cs
+++ b/WinBGMute/MainForm.cs
@@ -744,13 +744,15 @@ along with this program.If not, see < https://www.gnu.org/licenses/>
         private void BackGroundRadioButton_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.IsMuteConditionBackground = true;
-            m_isMuteConditionBackground = true; 
+            m_isMuteConditionBackground = true;
+            RunMuter(-1);
         }
 
         private void MinimizedRadioButton_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.IsMuteConditionBackground = false;
             m_isMuteConditionBackground = false;
+            RunMuter(-1);
         }
 
         private void MuteConditionGroupBox_Enter(object sender, EventArgs e)


### PR DESCRIPTION
Fix: Mute and unmute properly.
When mute condition is background, all background processes are muted.
When mute condition is minimized, unminimized processes are unmuted.

Update: Reflect condition setting immediately.