### PR TITLE
Fix to get all windows and update .NET version

### DIFF
--- a/WinBGMute/MainForm.cs
+++ b/WinBGMute/MainForm.cs
@@ -149,22 +149,13 @@ namespace WinBGMuter
             // clear process list
             ProcessListListBox.Items.Clear();
 
-            // get a process PID list of processes with an audio channel
-            int[] audio_pids = m_volumeMixer.GetPIDs();
-
-            // populate dictionary audio_procs for each PID in audio_pids with KEY=<PID>, VALUE=tuple(<PROCESS_NAME>, <Process>)
-            foreach (var pid in audio_pids)
+            foreach (System.Diagnostics.Process proc in System.Diagnostics.Process.GetProcesses())
             {
+                //Only when title exists
+                if (proc.MainWindowTitle.Length == 0) continue;
+                int pid = proc.Id;
                 try
                 {
-                    Process proc = Process.GetProcessById(pid);
-                    /*
-                    if (proc.HasExited)
-                    {
-                        LoggingEngine.LogLine($"[!] PID with audio channel {pid} has exited! This will likely trigger an error");
-                    }
-
-                    */
                     string pname = proc.ProcessName;
 
                     //add proc name to ListBox if it will be muted

--- a/WinBGMute/WinBGMuter.csproj
+++ b/WinBGMute/WinBGMuter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Current way to get processes is incomplete but simple way to get processes works correctly. related to #25
And .NET6 support will soon disappear, fix to use .NET8. related to #9 #38