### PR TITLE
fix: memory leak in ReloadAudio - properly release COM objects

### DIFF
--- a/WinBGMute/VolumeMixer.cs
+++ b/WinBGMute/VolumeMixer.cs
@@ -1,4 +1,4 @@
-﻿/* Modified from original code by Simon Mourier and Anders Carstensen
+/* Modified from original code by Simon Mourier and Anders Carstensen
  https://stackoverflow.com/questions/20938934/controlling-applications-volume-by-process-id */
 
 /*
@@ -169,7 +169,25 @@ namespace WinBGMuter
                     AudioDevice.mgr = (IAudioSessionManager2)AudioDevice.o;
                 }
 
-                //code takes too long
+                // [FIX] Release old volumeSessionList COM objects before clearing
+                if (AudioDevice.volumeSessionList is not null && AudioDevice.volumeSessionList.Count > 0)
+                {
+                    foreach (var vs in AudioDevice.volumeSessionList)
+                    {
+                        if (vs.Value is not null)
+                        {
+                            try { Marshal.ReleaseComObject(vs.Value); } catch { }
+                        }
+                    }
+                    AudioDevice.volumeSessionList.Clear();
+                }
+
+                // [FIX] Release old sessionEnumerator before getting new one
+                if (AudioDevice.sessionEnumerator is not null)
+                {
+                    try { Marshal.ReleaseComObject(AudioDevice.sessionEnumerator); } catch { }
+                    AudioDevice.sessionEnumerator = null;
+                }
 
                 AudioDevice.mgr.GetSessionEnumerator(out AudioDevice.sessionEnumerator);
                 if (AudioDevice.sessionEnumerator == null)
@@ -178,9 +196,11 @@ namespace WinBGMuter
                 }
                 AudioDevice.sessionEnumerator.GetCount(out AudioDevice.count);
 
+                if (AudioDevice.volumeSessionList == null)
+                {
+                    AudioDevice.volumeSessionList = new Dictionary<int, ISimpleAudioVolume?>();
+                }
 
-
-                AudioDevice.volumeSessionList.Clear();
                 ISimpleAudioVolume volumeControl = null;
                 for (int i = 0; i < AudioDevice.count; i++)
                 {
@@ -193,12 +213,12 @@ namespace WinBGMuter
 
                     if (AudioDevice.volumeSessionList.ContainsKey(cpid))
                     {
+                        // [FIX] Release old COM object before replacing
+                        if (AudioDevice.volumeSessionList[cpid] is not null)
+                        {
+                            try { Marshal.ReleaseComObject(AudioDevice.volumeSessionList[cpid]); } catch { }
+                        }
                         AudioDevice.volumeSessionList[cpid] = volumeControl;
-
-                        /*
-                        LoggingEngine.LogLine($"[!] PID {cpid} Exists ");
-                        AudioDevice.volumeSessionList.Remove(cpid);
-                        */
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
Fix memory leak in `VolumeMixer.ReloadAudio()` method where COM objects were not being properly released before being replaced or cleared.

## Problem
The original code had several issues in the `ReloadAudio()` method that caused memory leaks:

1. **volumeSessionList.Clear()** was called without releasing the COM objects stored in the dictionary first
2. **sessionEnumerator** was replaced with a new instance without releasing the old one
3. When updating an existing PID entry in the dictionary, the old COM object was not released before being replaced

Since `ReloadAudio()` is called frequently (every time audio sessions are queried), these unreleased COM objects accumulated over time, causing significant memory growth.

## Changes
- Release all COM objects in `volumeSessionList` before clearing the dictionary
- Release the old `sessionEnumerator` before getting a new one
- Release the old COM object when replacing an existing PID entry in the dictionary
- Added null checks and try-catch blocks to handle edge cases gracefully

## Testing
The fix has been tested and shows stable memory usage over extended periods of operation, compared to the continuously growing memory usage in the original code.

## Related Issues
This addresses the memory leak issue that users may have experienced when running Background Muter for extended periods.